### PR TITLE
Change the model saving line in `04_Train_and_Deploy/02_Train_Model.ipynb`

### DIFF
--- a/04_Train_and_Deploy/02_Train_Model.ipynb
+++ b/04_Train_and_Deploy/02_Train_Model.ipynb
@@ -153,7 +153,7 @@
     "\n",
     "\n",
     "#save\n",
-    "torch.save(model.model.module.state_dict(), 'nlprecipes_bert_ner.model')\n",
+    "torch.save(model.model.state_dict(), 'nlprecipes_bert_ner.model')\n",
     "\n",
     "# get hold of the current run\n",
     "run.upload_file(\"outputs/nlprecipes_bert_ner.model\", \"nlprecipes_bert_ner.model\")\n",


### PR DESCRIPTION
The original code model.model.module.state_dict() has error as the follow:

```
The experiment failed. Finalizing run...
[2020-08-14T06:11:57.530988] TimeoutHandler __init__
[2020-08-14T06:11:57.531029] TimeoutHandler __enter__
Cleaning up all outstanding Run operations, waiting 300.0 seconds
2 items cleaning up...
Cleanup took 0.21444201469421387 seconds
[2020-08-14T06:11:58.062100] TimeoutHandler __exit__
Traceback (most recent call last):
  File "train.py", line 97, in <module>
    torch.save(model.model.module.state_dict(), 'nlprecipes_bert_ner.model')
  File "/azureml-envs/azureml_233b47cf58dc26b71165c54f2239bffb/lib/python3.6/site-packages/torch/nn/modules/module.py", line 576, in __getattr__
    type(self).__name__, name))
AttributeError: 'BertForTokenClassification' object has no attribute 'module'
```
Since the base model is already nn.Module, I remove the `.module()` and it can successfully run.